### PR TITLE
add composer/composer to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "composer/composer": "^1.2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.7"


### PR DESCRIPTION
@jails This is to be able to use composer's ClassMapGenerator as your comment at https://github.com/kahlan/docs/pull/5#issuecomment-254952087