### PR TITLE
remove exit() method from $specs->status() in bin/kahlan

### DIFF
--- a/bin/kahlan
+++ b/bin/kahlan
@@ -45,4 +45,4 @@ $specs = new Kahlan([
 ]);
 $specs->loadConfig($argv);
 $specs->run();
-exit($specs->status());
+$specs->status();


### PR DESCRIPTION
when it run via `ant`, it will make BUILD FAILED with returned: 255 error.