### PR TITLE
assign $expectation->logs() to variable in Specification::_specEnd()

### DIFF
--- a/src/Specification.php
+++ b/src/Specification.php
@@ -185,10 +185,10 @@ class Specification extends Scope
     protected function _specEnd($runAfterEach = true)
     {
         foreach ($this->_expectations as $expectation) {
-            if (!$expectation->logs()) {
+            if (!($logs = $expectation->logs())) {
                 $this->log()->type('pending');
             }
-            foreach ($expectation->logs() as $log) {
+            foreach ($logs as $log) {
                 $this->log($log['type'], $log);
             }
         }


### PR DESCRIPTION
no need for repetitive `$expectation->logs()` call.