### PR TITLE
Mmalawski/die with non numeric message

### DIFF
--- a/spec/Suite/Plugin/Quit.spec.php
+++ b/spec/Suite/Plugin/Quit.spec.php
@@ -75,6 +75,40 @@ describe("Quit", function () {
 
     });
 
+    describe("::disable()", function () {
+
+        it("throws an exception when a die statement occurs with string message", function () {
+
+            Quit::disable();
+
+            $closure = function () {
+                $foo = new Foo();
+                $foo->dieStatement('error message');
+            };
+
+            expect($closure)->toThrow(new QuitException('Exit statement occurred with message: error message', 0));
+
+        });
+
+    });
+
+    describe("::disable()", function () {
+
+        it("throws an exception when a die statement occurs with integer code", function () {
+
+            Quit::disable();
+
+            $closure = function () {
+                $foo = new Foo();
+                $foo->dieStatement(-1);
+            };
+
+            expect($closure)->toThrow(new QuitException('Exit statement occurred', -1));
+
+        });
+
+    });
+
     describe("::reset()", function () {
 
         it("enables `exit()` call catching on reset", function () {

--- a/src/Plugin/Quit.php
+++ b/src/Plugin/Quit.php
@@ -39,13 +39,16 @@ class Quit
     /**
      * Run a controlled quit statement.
      *
-     * @param  integer              $status Use 0 for a successful exit.
+     * @param  integer|string              $status Use 0 for a successful exit.
      * @throws Kahlan\QuitException         Only if disableed is `true`.
      */
     public static function quit($status = 0)
     {
         if (static::enabled()) {
             exit($status);
+        }
+        if(!is_numeric($status)){
+            throw new QuitException('Exit statement occurred with message: '. $status, 0);
         }
         throw new QuitException('Exit statement occurred', $status);
     }

--- a/src/Plugin/Quit.php
+++ b/src/Plugin/Quit.php
@@ -47,8 +47,8 @@ class Quit
         if (static::enabled()) {
             exit($status);
         }
-        if(!is_numeric($status)){
-            throw new QuitException('Exit statement occurred with message: '. $status, 0);
+        if (!is_numeric($status)) {
+            throw new QuitException('Exit statement occurred with message: ' . $status, 0);
         }
         throw new QuitException('Exit statement occurred', $status);
     }


### PR DESCRIPTION
Problem with following die statement in tested code:

......
die('some message');
......

This caused:

PHP Fatal error:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in vendor/kahlan/kahlan/src/Plugin/Quit.php on line 50
