### PR TITLE
add src and spec dir information into terminal

### DIFF
--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -509,8 +509,8 @@ EOD;
                         'start'  => $this->_start,
                         'colors' => !$this->commandLine()->get('no-colors'),
                         'header' => !$this->commandLine()->get('no-header'),
-                        'src'    => $this->commandLine()->get('src')[0],
-                        'spec'   => $this->commandLine()->get('spec')[0],
+                        'src'    => $this->commandLine()->get('src'),
+                        'spec'   => $this->commandLine()->get('spec'),
                     ];
 
                     if (isset($output) && strlen($output) > 0) {

--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -508,7 +508,9 @@ EOD;
                     $params = $args + [
                         'start'  => $this->_start,
                         'colors' => !$this->commandLine()->get('no-colors'),
-                        'header' => !$this->commandLine()->get('no-header')
+                        'header' => !$this->commandLine()->get('no-header'),
+                        'src'    => $this->commandLine()->get('src')[0],
+                        'spec'   => $this->commandLine()->get('spec')[0],
                     ];
 
                     if (isset($output) && strlen($output) > 0) {

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -67,6 +67,21 @@ class Terminal extends Reporter
         'dot'   => '.'
     ];
 
+
+    /**
+     * src directory to be tested.
+     *
+     * @var string
+     */
+    protected $_srcDir = 'src';
+
+    /**
+     * spec directory.
+     *
+     * @var string
+     */
+    protected $_specDir = 'spec';
+
     /**
      * The constructor.
      *
@@ -93,6 +108,14 @@ class Terminal extends Reporter
             $this->_symbols['ok'] = "\xFB";
             $this->_symbols['err'] = "\x78";
             $this->_symbols['dot'] = '.';
+        }
+
+        if (isset($config['src'])) {
+            $this->_srcDir  = $config['src'];
+        }
+
+        if (isset($config['spec'])) {
+            $this->_specDir = $config['spec'];
         }
     }
 
@@ -135,6 +158,10 @@ class Terminal extends Reporter
         $this->write($this->kahlanBaseline() . "\n", 'dark-grey');
         $this->write("\nWorking Directory: ", 'blue');
         $this->write(getcwd() . "\n");
+        $this->write("src Directory: ", 'blue');
+        $this->write(realpath($this->_srcDir) . "\n");
+        $this->write("spec Directory: ", 'blue');
+        $this->write(realpath($this->_specDir) . "\n");
     }
 
     /**

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -161,7 +161,7 @@ class Terminal extends Reporter
         $this->write("src Directory     : ", 'blue');
         $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
         $this->write("spec Directory    : ", 'blue');
-        $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
+        $this->write(join(', ', array_map('realpath', $this->_specDir)) . "\n");
     }
 
     /**

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -156,11 +156,11 @@ class Terminal extends Reporter
         }
         $this->write($this->kahlan() . "\n\n");
         $this->write($this->kahlanBaseline() . "\n", 'dark-grey');
-        $this->write("\nWorking Directory: ", 'blue');
+        $this->write("\nWorking Directory : ", 'blue');
         $this->write(getcwd() . "\n");
-        $this->write("src Directory: ", 'blue');
+        $this->write("src Directory     : ", 'blue');
         $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
-        $this->write("spec Directory: ", 'blue');
+        $this->write("spec Directory    : ", 'blue');
         $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
     }
 

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -159,9 +159,9 @@ class Terminal extends Reporter
         $this->write("\nWorking Directory: ", 'blue');
         $this->write(getcwd() . "\n");
         $this->write("src Directory: ", 'blue');
-        $this->write(realpath($this->_srcDir) . "\n");
+        $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
         $this->write("spec Directory: ", 'blue');
-        $this->write(realpath($this->_specDir) . "\n");
+        $this->write(join(', ', array_map('realpath', $this->_srcDir)) . "\n");
     }
 
     /**

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -71,16 +71,16 @@ class Terminal extends Reporter
     /**
      * src directory to be tested.
      *
-     * @var string
+     * @var array
      */
-    protected $_srcDir = 'src';
+    protected $_srcDir = ['src'];
 
     /**
      * spec directory.
      *
-     * @var string
+     * @var array
      */
-    protected $_specDir = 'spec';
+    protected $_specDir = ['spec'];
 
     /**
      * The constructor.


### PR DESCRIPTION
I think it is nice to have, so, we have information about : 

- working directory
- src directory
-  spec directory

in the terminal.

```
$ bin/kahlan 
            _     _
  /\ /\__ _| |__ | | __ _ _ __
 / //_/ _` | '_ \| |/ _` | '_ \
/ __ \ (_| | | | | | (_| | | | |
\/  \/\__,_|_| |_|_|\__,_|_| |_|

The PHP Test Framework for Freedom, Truth and Justice.

Working Directory: /Users/samsonasik/www/kahlan
src Directory: /Users/samsonasik/www/kahlan/src
spec Directory: /Users/samsonasik/www/kahlan/spec

...............................................................  63 / 935 (  6%)
............................................................... 126 / 935 ( 13%)
```