### PR TITLE
hhvm h4cc badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm-3.18
+  - hhvm
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
try fix hhvm h4cc badge by reset hhvm-3.18 definition to hhvm. 
It was changed #238 because of "hhvm" undetected in xenial, which changed to trusty