### PR TITLE
External expectations

### DIFF
--- a/spec/Suite/ExternalExpectation.spec.php
+++ b/spec/Suite/ExternalExpectation.spec.php
@@ -1,0 +1,60 @@
+<?php
+namespace Kahlan\Spec\Suite;
+
+use InvalidArgumentException;
+use Kahlan\ExternalExpectation;
+use RuntimeException;
+
+function externalExpectation($callback, $type = 'Exception')
+{
+    return new ExternalExpectation(compact('callback', 'type'));
+}
+
+describe("ExternalExpectation", function () {
+
+    describe("->process()", function () {
+
+        it("should handle passes", function () {
+
+            $actual = externalExpectation(function () {});
+            expect($actual->process())->toBe(true);
+
+            $logs = $actual->logs();
+            expect($logs)->toHaveLength(1);
+            expect($logs[0])->toBe(['type' => 'passed']);
+
+        });
+
+        it("should handle failures", function () {
+
+            $expected = new RuntimeException('Failure description.');
+            $actual = externalExpectation(function () use ($expected) {
+                throw $expected;
+            });
+            expect($actual->process())->toBe(false);
+
+            $logs = $actual->logs();
+            expect($logs)->toHaveLength(1);
+            expect($logs[0]['type'])->toBe('failed');
+            expect($logs[0]['data'])->toBe(['external' => true, 'description' => $expected->getMessage()]);
+            expect($logs[0]['backtrace'])->toBe($expected->getTrace());
+
+        });
+
+        it("should handle errors", function () {
+
+            $expected = new InvalidArgumentException();
+            $actual = externalExpectation(function () use ($expected) {
+                throw $expected;
+            }, 'RuntimeException');
+            $callback = function () use ($actual) {
+                $actual->process();
+            };
+            expect($callback)->toThrow($expected);
+            expect($actual->logs())->toHaveLength(0);
+
+        });
+
+    });
+
+});

--- a/src/Block/Specification.php
+++ b/src/Block/Specification.php
@@ -2,11 +2,12 @@
 namespace Kahlan\Block;
 
 use Closure;
-use Throwable;
 use Exception;
 use Kahlan\Expectation;
-use Kahlan\Suite;
+use Kahlan\ExternalExpectation;
 use Kahlan\Scope\Specification as Scope;
+use Kahlan\Suite;
+use Throwable;
 
 class Specification extends \Kahlan\Block
 {
@@ -48,6 +49,20 @@ class Specification extends \Kahlan\Block
     public function expect($actual, $timeout = -1)
     {
         return $this->_expectations[] = new Expectation(compact('actual', 'timeout'));
+    }
+
+    /**
+     * The expectExternal statement.
+     *
+     * @param array $config The config array. Options are:
+     *                       -`'callback'` _callable_ : the callback to execute.
+     *                       -`'type'`     _string_   : the supported exception type.
+     *
+     * @return Expectation
+     */
+    public function expectExternal($config = [])
+    {
+        return $this->_expectations[] = new ExternalExpectation($config);
     }
 
     /**

--- a/src/ExternalExpectation.php
+++ b/src/ExternalExpectation.php
@@ -1,0 +1,90 @@
+<?php
+namespace Kahlan;
+
+use Exception;
+use Kahlan\Analysis\Debugger;
+use Throwable;
+
+/**
+ * Class ExternalExpectation
+ */
+class ExternalExpectation extends Expectation
+{
+    /**
+     * The external callback.
+     *
+     * @var callable
+     */
+    protected $_callback;
+
+    /**
+     * The supported exception type.
+     *
+     * @var string
+     */
+    protected $_type;
+
+    /**
+     * Constructor.
+     *
+     * @param array $config The config array. Options are:
+     *                       -`'callback'` _callable_ : the callback to execute.
+     *                       -`'type'`     _string_   : the supported exception type.
+     */
+    public function __construct($config = [])
+    {
+        $defaults = [
+            'callback' => function () {},
+            'type' => 'Exception',
+        ];
+        $config += $defaults;
+
+        $this->_callback = $config['callback'];
+        $this->_type = $config['type'];
+
+        parent::__construct($config);
+    }
+
+    /**
+     * Processes the expectation.
+     *
+     * @return mixed
+     */
+    protected function _process()
+    {
+        $result = null;
+        $exception = null;
+
+        try {
+            $result = call_user_func($this->_callback);
+        } catch (Throwable $e) {
+            $exception = $e;
+        } catch (Exception $e) {
+            $exception = $e;
+        }
+
+        if (!$exception) {
+            $this->_logs[] = ['type' => 'passed'];
+            $this->_passed = true;
+
+            return $result;
+        }
+
+        $this->_passed = false;
+
+        if (!$exception instanceof $this->_type) {
+            throw $exception;
+        }
+
+        $this->_logs[] = [
+            'type' => 'failed',
+            'data' => [
+                'external' => true,
+                'description' => $exception->getMessage()
+            ],
+            'backtrace' => Debugger::normalize($exception->getTrace())
+        ];
+
+        return false;
+    }
+}

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -265,11 +265,26 @@ EOD;
                     if ($expectation->type() !== 'failed') {
                         continue;
                     }
-                    $this->write("expect->{$expectation->matcherName()}() failed in ", 'red');
+
+                    $data = $expectation->data();
+                    $isExternal = isset($data['external']) && $data['external'];
+
+                    if ($isExternal) {
+                        $this->write("expectation failed in ", 'red');
+                    } else {
+                        $this->write("expect->{$expectation->matcherName()}() failed in ", 'red');
+                    }
+
                     $this->write("`{$expectation->file()}` ");
                     $this->write("line {$expectation->line()}", 'red');
                     $this->write("\n\n");
-                    $this->_reportDiff($expectation);
+
+                    if ($isExternal) {
+                        $this->write($data['description']);
+                        $this->write("\n\n");
+                    } else {
+                        $this->_reportDiff($expectation);
+                    }
                 }
                 break;
             case "errored":


### PR DESCRIPTION
This PR implements a way for third-party libraries to create expectations in Kahlan without using the standard `expect()` interface, and with greater control over how failure descriptions are rendered.

These "external" expectations work by converting thrown exceptions of a certain type into Kahlan-style "failed" log entries. In addition, they log a "passed" entry if no exception is thrown, and only catch exceptions of an expected type.

When rendered in the terminal, the failure descriptions are displayed without the formatting normally applied to internal failures. This allows third-party libraries to display failures in Kahlan's output with whatever formatting they desire.

Example usage (Phony integration):

```php
    // ...

    /**
     * Create a new assertion failure exception.
     *
     * @param string $description The failure description.
     *
     * @throws Exception If this recorder throws exceptions.
     */
    public function createFailure($description)
    {
        $exception = new AssertionException($description);

        Suite::current()->expectExternal([
            'callback' => function () use ($exception) {
                throw $exception;
            },
            'type' => AssertionException::class,
        ]);
    }

    // ...
```

Example usage (imaginary external assertion library):

```php
function equalTo($actual, $expected)
{
    Suite::current()->expectExternal([
        'callback' => function () use ($actual, $expected) {
            MyAssertions::equalTo($actual, $expected);
        },
        'type' => MyAssertionException::class,
    ]);
}
```