### PR TITLE
Implemented __toString() for argument matchers.

### DIFF
--- a/spec/Suite/Arg.spec.php
+++ b/spec/Suite/Arg.spec.php
@@ -86,4 +86,43 @@ describe("Arg", function () {
 
     });
 
+    describe("->__toString()", function () {
+
+        it("describes the argument matcher", function () {
+
+            $arg = Arg::toBe(true);
+            expect(strval($arg))->toBe('toBe(true)');
+
+        });
+
+        it("describes argument matchers with multiple arguments", function () {
+
+            $arg = Arg::toBeCloseTo(1, 2);
+            expect(strval($arg))->toBe('toBeCloseTo(1, 2)');
+
+        });
+
+        it("describes argument matchers with no arguments", function () {
+
+            $arg = Arg::toBeTruthy();
+            expect(strval($arg))->toBe('toBeTruthy()');
+
+        });
+
+        it("describes argument matchers with array arguments", function () {
+
+            $arg = Arg::toBe([1, 2]);
+            expect(strval($arg))->toBe('toBe(array[2])');
+
+        });
+
+        it("describes argument matchers with object arguments", function () {
+
+            $arg = Arg::toBe((object) [1, 2]);
+            expect(strval($arg))->toBe('toBe(object[stdClass])');
+
+        });
+
+    });
+
 });

--- a/src/Arg.php
+++ b/src/Arg.php
@@ -2,6 +2,7 @@
 namespace Kahlan;
 
 use Exception;
+use Kahlan\Util\Text;
 
 /**
  * Class Arg
@@ -136,5 +137,40 @@ class Arg
         array_unshift($args, $actual);
         $boolean = call_user_func_array($matcher . '::match', $args);
         return $this->_not ? !$boolean : $boolean;
+    }
+
+    /**
+     * Returns the description of this argument matcher.
+     *
+     * @return string The description of this argument matcher.
+     */
+    public function __toString()
+    {
+        return sprintf(
+            '%s(%s)',
+            $this->_name,
+            implode(
+                ', ',
+                array_map([Arg::class, '_describeArg'], $this->_args)
+            )
+        );
+    }
+
+    /**
+     * Generate an inline string representation of an argument.
+     *
+     * @param mixed $arg The argument.
+     * @return string    The dumped string.
+     */
+    public static function _describeArg($arg)
+    {
+        if (is_array($arg)) {
+            return sprintf('array[%d]', count($arg));
+        }
+        if (is_object($arg)) {
+            return sprintf('object[%s]', get_class($arg));
+        }
+
+        return Text::toString($arg);
     }
 }


### PR DESCRIPTION
This PR allows third-party libraries to generate a string description of argument matchers, for better integration.

Example usage (Phony integration):

```php
    // ...

    it('should support argument matcher integrations', function () {
        $this->mock->methodA(111);
        $this->mock->methodA(222);

        $this->handle->methodA->calledWith(Arg::toBeGreaterThan(333));
    });

    // ...
```

Produces output:

    Expected TestClassA[2]->methodA call with arguments:
        ✗ <toBeGreaterThan(333)> (0 matches)
    Matched 0 of 2:
    ✗ Call #0:
        ✗ 111
    ✗ Call #1:
        ✗ 222