### PR TITLE
[4.0] update php requirement to 5.5+ in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the whole [documentation here](https://kahlan.github.io/docs)
 
 ## Requirements
 
- * PHP 5.4+
+ * PHP 5.5+
  * Composer
  * [phpdbg](http://php.net/manual/en/debugger-about.php) or [Xdebug](http://xdebug.org/) (required for code coverage analysis only)
 


### PR DESCRIPTION
@jails based on travis update to remove php 5.4 https://github.com/kahlan/kahlan/commit/f6ea0f3c653f76fb8b1daec47d6f7439af8179ef