### PR TITLE
Fix for #279

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 codeclimate.json
 coveralls.json
 clover.xml
+/.project

--- a/spec/Suite/Suite.spec.php
+++ b/spec/Suite/Suite.spec.php
@@ -1288,6 +1288,17 @@ describe("Suite", function () {
 
         });
 
+	    it('ignores supressed errors', function() {
+
+		    $closure = function () {
+			    $failing = function() {
+				    $a = $b;
+			    };
+			    @$failing();
+		    };
+		    expect($closure)->not->toThrow(new PhpErrorException("`E_NOTICE` Undefined variable: b"));
+	    });
+
     });
 
     describe("->reporters()", function () {

--- a/spec/Suite/Suite.spec.php
+++ b/spec/Suite/Suite.spec.php
@@ -1288,16 +1288,16 @@ describe("Suite", function () {
 
         });
 
-	    it('ignores supressed errors', function() {
+        it( 'ignores supressed errors', function () {
 
-		    $closure = function () {
-			    $failing = function() {
-				    $a = $b;
-			    };
-			    @$failing();
-		    };
-		    expect($closure)->not->toThrow(new PhpErrorException("`E_NOTICE` Undefined variable: b"));
-	    });
+            $closure = function () {
+                $failing = function () {
+                    $a = $b;
+                };
+                @$failing();
+            };
+            expect($closure)->not->toThrow();
+        });
 
     });
 

--- a/spec/Suite/Suite.spec.php
+++ b/spec/Suite/Suite.spec.php
@@ -1288,7 +1288,7 @@ describe("Suite", function () {
 
         });
 
-        it( 'ignores supressed errors', function () {
+        it('ignores supressed errors', function () {
 
             $closure = function () {
                 $failing = function () {

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -160,6 +160,9 @@ class Suite
             return restore_error_handler();
         }
         $handler = function ($code, $message, $file, $line = 0, $args = []) {
+	        if (0 === error_reporting()) {
+		        return;
+	        }
             $trace = debug_backtrace();
             $trace = array_slice($trace, 1, count($trace));
             $message = "`" . Debugger::errorType($code) . "` {$message}";

--- a/src/Suite.php
+++ b/src/Suite.php
@@ -160,9 +160,9 @@ class Suite
             return restore_error_handler();
         }
         $handler = function ($code, $message, $file, $line = 0, $args = []) {
-	        if (0 === error_reporting()) {
-		        return;
-	        }
+            if (0 === error_reporting()) {
+                return;
+            }
             $trace = debug_backtrace();
             $trace = array_slice($trace, 1, count($trace));
             $message = "`" . Debugger::errorType($code) . "` {$message}";


### PR DESCRIPTION
Currently it is not possible to test code, that relies on the Error Control Operator `@`. This is due to the fact that this operator still calls the custom error handling function and only changes the value of `error_reporting()` to 0.
I would therefore suggest that the default error handler checks if error_reporting is set to 0 and if so, doesn't throw a `PhpErrorException`.