### PR TITLE
Add 'fakeMethods' and 'stubMethods' to Kahlan\Plugin\Double::instance()

### DIFF
--- a/spec/Suite/Plugin/Double.spec.php
+++ b/spec/Suite/Plugin/Double.spec.php
@@ -54,7 +54,7 @@ describe("Double", function () {
 
     });
 
-    describe("::create()", function () {
+    describe("::instance()", function () {
 
         beforeAll(function () {
             $this->is_method_exists = function ($instance, $method, $type = "public") {
@@ -245,6 +245,42 @@ describe("Double", function () {
             $double = Double::instance();
             $double->message();
             expect($double)->not->toReceive('message');
+
+        });
+
+        it("stubs methods with return values via 'stubMethods' option", function () {
+
+            $anotherDouble = Double::instance();
+            $double = Double::instance(['stubMethods' => [
+                'foo' => ['this', 'is', 'foo'],
+                'bar' => 'Hello Bar!',
+                'baz' => $anotherDouble
+            ]]);
+
+            expect($double->foo())->toBe(['this', 'is', 'foo']);
+            expect($double->bar())->toBe('Hello Bar!');
+            expect($double->baz())->toBe($anotherDouble);
+
+        });
+
+        it("stubs methods with callbacks via 'fakeMethods' option", function () {
+
+            $anotherDouble = Double::instance();
+            $double = Double::instance(['fakeMethods' => [
+                'foo' => function () {
+                    return ['this', 'is', 'foo'];
+                },
+                'bar' => function () {
+                    return 'Hello Bar!';
+                },
+                'baz' => function () use ($anotherDouble) {
+                    return $anotherDouble;
+                }
+            ]]);
+
+            expect($double->foo())->toBe(['this', 'is', 'foo']);
+            expect($double->bar())->toBe('Hello Bar!');
+            expect($double->baz())->toBe($anotherDouble);
 
         });
 

--- a/src/Plugin/Double.php
+++ b/src/Plugin/Double.php
@@ -45,10 +45,12 @@ class Double
      * Creates a polyvalent instance.
      *
      * @param  array  $options Array of options. Options are:
-     *                         - `'class'`   _string_: the fully-namespaced class name.
-     *                         - `'extends'` _string_: the fully-namespaced parent class name.
-     *                         - `'args'`    _array_:  arguments to pass to the constructor.
-     *                         - `'methods'` _string_: override the method defined.
+     *                         - `'class'`       string: the fully-namespaced class name.
+     *                         - `'extends'`     string: the fully-namespaced parent class name.
+     *                         - `'args'`        array : arguments to pass to the constructor.
+     *                         - `'methods'`     string: override given methods with empty functions.
+     *                         - `'stubMethods'` array : override given methods to return given values, e.g. ['foo' => 'bar'].
+     *                         - `'fakeMethods'` array : override given methods to run given callback, e.g. ['foo' => function () { return 'bar'; }].
      * @return object          The created instance.
      */
     public static function instance($options = [])
@@ -60,6 +62,16 @@ class Double
             $instance = $refl->newInstanceArgs($options['args']);
         } else {
             $instance = new $class();
+        }
+        if (isset($options['stubMethods']) && is_array($options['stubMethods'])) {
+            foreach ($options['stubMethods'] as $name => $return) {
+                allow($instance)->toReceive($name)->andReturn($return);
+            }
+        }
+        if (isset($options['fakeMethods']) && is_array($options['fakeMethods'])) {
+            foreach ($options['fakeMethods'] as $name => $callback) {
+                allow($instance)->toReceive($name)->andRun($callback);
+            }
         }
         return $instance;
     }

--- a/src/Plugin/Double.php
+++ b/src/Plugin/Double.php
@@ -45,12 +45,12 @@ class Double
      * Creates a polyvalent instance.
      *
      * @param  array  $options Array of options. Options are:
-     *                         - `'class'`       string: the fully-namespaced class name.
-     *                         - `'extends'`     string: the fully-namespaced parent class name.
-     *                         - `'args'`        array : arguments to pass to the constructor.
-     *                         - `'methods'`     string: override given methods with empty functions.
-     *                         - `'stubMethods'` array : override given methods to return given values, e.g. ['foo' => 'bar'].
-     *                         - `'fakeMethods'` array : override given methods to run given callback, e.g. ['foo' => function () { return 'bar'; }].
+     *                         - `'class'`       string  : the fully-namespaced class name.
+     *                         - `'extends'`     string  : the fully-namespaced parent class name.
+     *                         - `'args'`        array   : arguments to pass to the constructor.
+     *                         - `'methods'`     string[]: override given methods with empty functions.
+     *                         - `'stubMethods'` array   : override given methods to return given values, e.g. ['foo' => 'bar'].
+     *                         - `'fakeMethods'` array   : override given methods to run given callback, e.g. ['foo' => function () { return 'bar'; }].
      * @return object          The created instance.
      */
     public static function instance($options = [])


### PR DESCRIPTION
'fakeMethods' allows to define methods with fake implementation with
callbacks.
'stubMethods' allows to define methods with it's return values.
Fixed wrong describe, there is no longer 'Double::create', it is
'Double::instance()' now.

Ref #307