### PR TITLE
restore_include_path() is deprecated in php 7.4, replace with ini_restore('include_path')

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - nightly
 
 matrix:
   allow_failures:
+    - php: 7.4snapshot
     - php: nightly
   fast_finish: true
 

--- a/src/Jit/ClassLoader.php
+++ b/src/Jit/ClassLoader.php
@@ -249,7 +249,7 @@ class ClassLoader
         $includePath = get_include_path();
         set_include_path($includePath ? $includePath . ':' . dirname($file) : dirname($file));
         require $cached;
-        restore_include_path();
+        ini_restore('include_path');
         return true;
     }
 


### PR DESCRIPTION
refs: https://3v4l.org/Kcs98