### PR TITLE
Add a new reporter `Tree`

### DIFF
--- a/spec/Suite/Cli/Kahlan.spec.php
+++ b/spec/Suite/Cli/Kahlan.spec.php
@@ -159,7 +159,7 @@ Configuration Options:
 Reporter Options:
 
   --reporter=<name>[:<output_file>]   The name of the text reporter to use, the built-in text reporters
-                                      are `'dot'`, `'bar'`, `'json'`, `'tap'` & `'verbose'` (default: `'dot'`).
+                                      are `'dot'`, `'bar'`, `'json'`, `'tap'`, `'tree'` & `'verbose'` (default: `'dot'`).
                                       You can optionally redirect the reporter output to a file by using the
                                       colon syntax (multiple --reporter options are also supported).
 

--- a/spec/Suite/Reporter/Console/end.txt
+++ b/spec/Suite/Reporter/Console/end.txt
@@ -1,0 +1,42 @@
+  
+  Pending specification: 1
+  ./spec/UnionTypes.spec.php, line 119
+  
+  Excluded specification: 1
+  ./spec/UnionTypes.spec.php, line 126
+  
+  Skipped specification: 1
+  ./spec/UnionTypes.spec.php, line 134
+  
+  Failure Tree(2):
+  ├── UnionTypes
+  │  ├── ::assertTypes(string ...$types): void
+  │  │  ├── UnionTypes::assertTypes('NULL')
+  │  │  ✖   it should throw InvalidUnionTypeException `NULL`, use `null` instead
+    expect->toBe() failed in `./spec/UnionTypes.spec.php` line 125
+    
+    It expect actual to be identical to expected (===).
+    
+    actual:
+      (string) "string"
+    expected:
+      (NULL) null
+    
+  ├── UnionTypes
+  │  ├── ::assertTypes(string ...$types): void
+  │  │  ├── UnionTypes::assertTypes('integer')
+  │  │  ✖   it should throw InvalidUnionTypeException `integer`, use `int` instead
+    an uncaught exception has been thrown in `./vendor/kahlan/kahlan/src/Matcher/ToBe.php` line 13
+    
+    message:`Kahlan\Spec\Suite\Reporter\Coverage\Exception` Code(0) with message "Too few arguments to function Kahlan\\Matcher\\ToBe::match(), 1 passed and exactly 2 expected"
+    
+      Kahlan\Matcher\ToBe::match() - ./vendor/kahlan/kahlan/src/Matcher/ToBe.php, line 13
+      Kahlan\Expectation::_spin() - ./vendor/kahlan/kahlan/src/Expectation.php, line 212
+      Kahlan\Expectation::__call() - ./spec/UnionTypes.spec.php, line 130
+    
+  
+  Expectations   : 3 Executed
+  Specifications : 1 Pending, 1 Excluded, 1 Skipped
+  
+  Passed 1 of 3 FAIL (FAILURE: 1, EXCEPTION: 1) in 0.040 seconds (using 2MB)
+  

--- a/spec/Suite/Reporter/Console/specEnd.txt
+++ b/spec/Suite/Reporter/Console/specEnd.txt
@@ -1,0 +1,6 @@
+  [0;90;49m[0m[0;92;49m✓[0m   [0;90;49mit should throw InvalidUnionTypeException `NULL`, use `null` instead[0m
+  [0;90;49m[0m[0;37;49m✓[0m   [0;37;49mit should throw InvalidUnionTypeException `integer`, use `int` instead[0m
+  [0;90;49m[0m[0;36;49m✓[0m   [0;36;49mit should return 'int'[0m
+  [0;90;49m[0m[0;33;49m✓[0m   [0;33;49mit should return 'float'[0m
+  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'float'[0m
+  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'Cake\ORM\Table'[0m

--- a/spec/Suite/Reporter/Console/specEnd.txt
+++ b/spec/Suite/Reporter/Console/specEnd.txt
@@ -1,6 +1,6 @@
-  [0;90;49m[0m[0;92;49m✓[0m   [0;90;49mit should throw InvalidUnionTypeException `NULL`, use `null` instead[0m
-  [0;90;49m[0m[0;37;49m✓[0m   [0;37;49mit should throw InvalidUnionTypeException `integer`, use `int` instead[0m
-  [0;90;49m[0m[0;36;49m✓[0m   [0;36;49mit should return 'int'[0m
-  [0;90;49m[0m[0;33;49m✓[0m   [0;33;49mit should return 'float'[0m
-  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'float'[0m
-  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'Cake\ORM\Table'[0m
+  ✓   it should throw InvalidUnionTypeException `NULL`, use `null` instead
+  ✓   it should throw InvalidUnionTypeException `integer`, use `int` instead
+  ✓   it should return 'int'
+  ✓   it should return 'float'
+  ✖   it should return 'float'
+  ✖   it should return 'Cake\ORM\Table'

--- a/spec/Suite/Reporter/Console/start.txt
+++ b/spec/Suite/Reporter/Console/start.txt
@@ -4,9 +4,9 @@
   / __ \ (_| | | | | | (_| | | | |
   \/  \/\__,_|_| |_|_|\__,_|_| |_|
   
-  [0;90;49mThe PHP Test Framework for Freedom, Truth and Justice.
+  The PHP Test Framework for Freedom, Truth and Justice.
   
-[0m  [0;34;49msrc directory  : [0m/Volumes/Data/Git/github/kahlan/src
-  [0;34;49mspec directory : [0m/Volumes/Data/Git/github/kahlan/spec
+  src directory  : /Volumes/Data/Git/github/kahlan/src
+  spec directory : /Volumes/Data/Git/github/kahlan/spec
   
-  [0;34;49mSpec Tree:[0m
+  Spec Tree:

--- a/spec/Suite/Reporter/Console/start.txt
+++ b/spec/Suite/Reporter/Console/start.txt
@@ -1,0 +1,12 @@
+              _     _
+    /\ /\__ _| |__ | | __ _ _ __
+   / //_/ _` | '_ \| |/ _` | '_ \
+  / __ \ (_| | | | | | (_| | | | |
+  \/  \/\__,_|_| |_|_|\__,_|_| |_|
+  
+  [0;90;49mThe PHP Test Framework for Freedom, Truth and Justice.
+  
+[0m  [0;34;49msrc directory  : [0m/Volumes/Data/Git/github/kahlan/src
+  [0;34;49mspec directory : [0m/Volumes/Data/Git/github/kahlan/spec
+  
+  [0;34;49mSpec Tree:[0m

--- a/spec/Suite/Reporter/Console/suiteStart.txt
+++ b/spec/Suite/Reporter/Console/suiteStart.txt
@@ -1,5 +1,5 @@
-  [0;90;49m│  ├── [0m::assertTypes(string ...$types): void
-  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('NULL')
-  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('integer')
-  [0;90;49m│  ├── [0m::getType(mixed $value): string
-  [0;90;49m│  │  ├── [0mUnionTypes::getType(1)
+  │  ├── ::assertTypes(string ...$types): void
+  │  │  ├── UnionTypes::assertTypes('NULL')
+  │  │  ├── UnionTypes::assertTypes('integer')
+  │  ├── ::getType(mixed $value): string
+  │  │  ├── UnionTypes::getType(1)

--- a/spec/Suite/Reporter/Console/suiteStart.txt
+++ b/spec/Suite/Reporter/Console/suiteStart.txt
@@ -1,0 +1,5 @@
+  [0;90;49m│  ├── [0m::assertTypes(string ...$types): void
+  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('NULL')
+  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('integer')
+  [0;90;49m│  ├── [0m::getType(mixed $value): string
+  [0;90;49m│  │  ├── [0mUnionTypes::getType(1)

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -1,0 +1,252 @@
+<?php
+namespace Kahlan\Spec\Suite\Reporter\Coverage;
+
+use Kahlan\Reporter\Tree;
+
+class Suite
+{
+    protected $_messages = [];
+
+    public function __construct(array $messages)
+    {
+        $this->_messages = $messages;
+    }
+
+    public function messages(): array
+    {
+        return $this->_messages;
+    }
+}
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+class Log
+{
+    protected $_type = '';
+    protected $_messages = [];
+
+    public function __construct(string $type, array $messages)
+    {
+        $this->_type = $type;
+        $this->_messages = $messages;
+    }
+
+    public function type(): string
+    {
+        return $this->_type;
+    }
+
+    public function messages(): array
+    {
+        return $this->_messages;
+    }
+}
+
+describe("Tree", function () {
+
+    $eraseFile = function (string $file): bool {
+        $file = fopen($file, 'w');
+        fwrite($file, '');
+
+        return fclose($file);
+    };
+    $DS = DIRECTORY_SEPARATOR;
+    $REPORTER = __DIR__;
+    $ROOT = realpath($REPORTER . $DS . '..' . $DS . '..' . $DS . '..');
+    $SRC = $ROOT . $DS . 'src';
+    $SPEC = $ROOT . $DS . 'spec';
+
+    //region $start
+    $start = <<<EOD
+              _     _
+    /\ /\__ _| |__ | | __ _ _ __
+   / //_/ _` | '_ \| |/ _` | '_ \
+  / __ \ (_| | | | | | (_| | | | |
+  \/  \/\__,_|_| |_|_|\__,_|_| |_|
+  
+  [0;90;49mThe PHP Test Framework for Freedom, Truth and Justice.
+  
+[0m  [0;34;49msrc directory  : [0m$SRC
+  [0;34;49mspec directory : [0m$SPEC
+  
+  [0;34;49mSpec Tree:[0m
+
+EOD;
+    //endregion
+
+    //region $suiteStart
+    $suiteStart = <<<EOD
+  [0;90;49m│  ├── [0m::assertTypes(string ...\$types): void
+  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('NULL')
+  [0;90;49m│  │  ├── [0mUnionTypes::assertTypes('integer')
+  [0;90;49m│  ├── [0m::getType(mixed \$value): string
+  [0;90;49m│  │  ├── [0mUnionTypes::getType(1)
+
+EOD;
+    //endregion
+
+    //region $specEnd
+    $specEnd = <<<EOD
+  [0;90;49m[0m[0;92;49m✓[0m   [0;90;49mit should throw InvalidUnionTypeException `NULL`, use `null` instead[0m
+  [0;90;49m[0m[0;37;49m✓[0m   [0;37;49mit should throw InvalidUnionTypeException `integer`, use `int` instead[0m
+  [0;90;49m[0m[0;36;49m✓[0m   [0;36;49mit should return 'int'[0m
+  [0;90;49m[0m[0;33;49m✓[0m   [0;33;49mit should return 'float'[0m
+  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'float'[0m
+  [0;90;49m[0m[0;31;49m✖[0m   [0;31;49mit should return 'Cake\ORM\Table'[0m
+
+EOD;
+    //endregion
+
+    describe('->start($args)', function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $start) {
+        $it = function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $start) {
+            $file = $REPORTER . $DS . 'Console' . $DS . 'start.txt';
+            $eraseFile($file);
+
+            $tree = new Tree(['output' => fopen($file, 'w'), 'src' => [$SRC], 'spec' => [$SPEC]]);
+            $tree->start(['total' => 0]);
+
+            $expect = file_get_contents($file);
+            expect($expect)->toBe($start);
+        };
+        it("should write the `start` message to the console", $it);
+    });
+
+    describe('->suiteStart($suite = null)', function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $suiteStart) {
+        it('should return if `$suite === null`', function () {
+            $tree = new Tree();
+            $expect = $tree->suiteStart(null);
+            expect($expect)->toBeNull();
+        });
+
+        $messagesSuite = [
+            [
+                0 => ""
+            ],
+            [
+                0 => "",
+                1 => "UnionTypes",
+                2 => '::assertTypes(string ...$types): void',
+            ],
+            [
+                0 => "",
+                1 => "UnionTypes",
+                2 => '::assertTypes(string ...$types): void',
+                3 => "UnionTypes::assertTypes('NULL')",
+            ],
+            [
+                0 => "",
+                1 => "UnionTypes",
+                2 => '::assertTypes(string ...$types): void',
+                3 => "UnionTypes::assertTypes('integer')",
+            ],
+            [
+                0 => "",
+                1 => "UnionTypes",
+                2 => '::getType(mixed $value): string',
+            ],
+            [
+                0 => "",
+                1 => "UnionTypes",
+                2 => '::getType(mixed $value): string',
+                3 => "UnionTypes::getType(1)",
+            ]
+        ];
+        $it = function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $suiteStart, $messagesSuite) {
+            $file = $REPORTER . $DS . 'Console' . $DS . 'suiteStart.txt';
+            $eraseFile($file);
+
+            $tree = new Tree(['output' => fopen($file, 'w'), 'src' => [$SRC], 'spec' => [$SPEC]]);
+            foreach ($messagesSuite as $messages) {
+                $tree->suiteStart(new Suite($messages));
+            }
+
+            $expect = file_get_contents($file);
+            expect($expect)->toBe($suiteStart);
+        };
+        it("should write the `suiteStart` message to the console", $it);
+    });
+
+    describe('->specEnd($log = null)', function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $specEnd) {
+        it('should return if `$log === null`', function () {
+            $tree = new Tree();
+            $expect = $tree->specEnd(null);
+            expect($expect)->toBeNull();
+        });
+
+        $messagesLog = [
+            [
+                'type' => 'passed',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::assertTypes(string ...$types): void',
+                    3 => "UnionTypes::assertTypes('NULL')",
+                    4 => "it should throw InvalidUnionTypeException `NULL`, use `null` instead",
+                ]
+            ],
+            [
+                'type' => 'skipped',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::assertTypes(string ...$types): void',
+                    3 => "UnionTypes::assertTypes('integer')",
+                    4 => "it should throw InvalidUnionTypeException `integer`, use `int` instead",
+                ],
+            ],
+            [
+                'type' => 'pending',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::getType(mixed $value): string',
+                    3 => "UnionTypes::getType(1)",
+                    4 => "it should return 'int'",
+                ]
+            ],
+            [
+                'type' => 'excluded',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::getType(mixed $value): string',
+                    3 => "UnionTypes::getType(1.2)",
+                    4 => "it should return 'float'",
+                ]
+            ],
+            [
+                'type' => 'failed',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::getType(mixed $value): string',
+                    3 => "UnionTypes::getType('1.2')",
+                    4 => "it should return 'float'",
+                ]
+            ],
+            [
+                'type' => 'errored',
+                'messages' => [
+                    0 => "",
+                    1 => "UnionTypes",
+                    2 => '::getType(mixed $value): string',
+                    3 => "UnionTypes::getType(new Table())",
+                    4 => "it should return 'Cake\ORM\Table'",
+                ]
+            ]
+        ];
+        $it = function () use ($eraseFile, $REPORTER, $DS, $SRC, $SPEC, $specEnd, $messagesLog) {
+            $file = $REPORTER . $DS . 'Console' . $DS . 'specEnd.txt';
+            $eraseFile($file);
+
+            $tree = new Tree(['output' => fopen($file, 'w'), 'src' => [$SRC], 'spec' => [$SPEC]]);
+            $tree->setCount(2);
+            foreach ($messagesLog as $log) {
+                $tree->specEnd(new Log((string)$log['type'], (array)$log['messages']));
+            }
+
+            $expect = file_get_contents($file);
+            expect($expect)->toBe($specEnd);
+        };
+        it("should write the `specEnd` message to the console", $it);
+    });
+});

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -24,7 +24,7 @@ class Log
     protected $_type = '';
     protected $_messages = [];
 
-    public function __construct(string $type, array $messages)
+    public function __construct($type, array $messages)
     {
         $this->_type = $type;
         $this->_messages = $messages;
@@ -43,7 +43,7 @@ class Log
 
 describe("Tree", function () {
 
-    $eraseFile = function (string $file) {
+    $eraseFile = function ($file) {
         $file = fopen($file, 'w');
         fwrite($file, '');
 

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -12,7 +12,7 @@ class Suite
         $this->_messages = $messages;
     }
 
-    public function messages(): array
+    public function messages()
     {
         return $this->_messages;
     }
@@ -30,12 +30,12 @@ class Log
         $this->_messages = $messages;
     }
 
-    public function type(): string
+    public function type()
     {
         return $this->_type;
     }
 
-    public function messages(): array
+    public function messages()
     {
         return $this->_messages;
     }
@@ -43,7 +43,7 @@ class Log
 
 describe("Tree", function () {
 
-    $eraseFile = function (string $file): bool {
+    $eraseFile = function (string $file) {
         $file = fopen($file, 'w');
         fwrite($file, '');
 

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -3,6 +3,7 @@ namespace Kahlan\Spec\Suite\Reporter\Coverage;
 
 use Kahlan\Reporter\Tree;
 
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
 class Suite
 {
     protected $_messages = [];

--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -282,7 +282,7 @@ Configuration Options:
 Reporter Options:
 
   --reporter=<name>[:<output_file>]   The name of the text reporter to use, the built-in text reporters
-                                      are `'dot'`, `'bar'`, `'json'`, `'tap'` & `'verbose'` (default: `'dot'`).
+                                      are `'dot'`, `'bar'`, `'json'`, `'tap'`, `'tree'` & `'verbose'` (default: `'dot'`).
                                       You can optionally redirect the reporter output to a file by using the
                                       colon syntax (multiple --reporter options are also supported).
 

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -1,0 +1,372 @@
+<?php
+declare(strict_types=1);
+
+namespace Kahlan\Reporter;
+
+class Tree extends Terminal
+{
+    /**
+     * Message counter for a specific suite.
+     *
+     * @var int
+     */
+    protected $_count = 0;
+
+    /**
+     * The console indentation.
+     *
+     * @var int
+     */
+    protected $_indent = 1;
+
+    /**
+     * The tree pipe, used to replace the indentation.
+     *
+     * ### Format
+     * ```php
+     * {PIPE}{BRANCH}{$message}
+     * ```
+     *
+     * ### Output Example
+     * ```
+     * ├── UnionTypes
+     * │  ├── ::assertTypes(string ...$types): void
+     * │  │  ├── UnionTypes::assertTypes('NULL')
+     * ```
+     *
+     * @var string
+     */
+    protected const PIPE = '│  ';
+
+    /**
+     * The tree branch, used only for desciption messages.
+     *
+     * ### Format
+     * ```php
+     * {PIPE}{BRANCH}{$message}
+     * ```
+     *
+     * ### Output Example
+     * ```
+     * ├── UnionTypes
+     * │  ├── ::assertTypes(string ...$types): void
+     * │  │  ├── UnionTypes::assertTypes('NULL')
+     * ```
+     *
+     * @var string
+     */
+    protected const BRANCH = '├── ';
+
+    /**
+     * The spec message separator, used to separate the symbol from the message.
+     *
+     * ### Format
+     * ```php
+     * {PIPE}{$symbol}{SPEC_MESSAGE_SEPARATOR}{$specMessage}
+     * ```
+     *
+     * ### Output Example
+     * ```
+     * ├── UnionTypes
+     * │  ├── ::assertTypes(string ...$types): void
+     * │  │  ├── UnionTypes::assertTypes('NULL')
+     * │  │  ✓   it should return 'null'
+     * ```
+     */
+    protected const SPEC_MESSAGE_SEPARATOR = '   ';
+
+    /**
+     * Callback called before any specs processing.
+     *
+     * ### Output Example
+     * ```
+     *              _     _
+     *    /\ /\__ _| |__ | | __ _ _ __
+     *   / //_/ _` | '_ \| |/ _` | '_ \
+     *  / __ \ (_| | | | | | (_| | | | |
+     *  \/  \/\__,_|_| |_|_|\__,_|_| |_|
+     *
+     *  The PHP Test Framework for Freedom, Truth and Justice.
+     *
+     *  src directory  : /php-union-types/src
+     *  spec directory : /php-union-types/spec
+     *
+     *  Spec Tree:
+     * ```
+     *
+     * @param array $args The suite arguments.
+     * @return void
+     */
+    public function start($args): void
+    {
+        parent::start($args);
+
+        $this->_writeNewLine();
+        $this->write("Spec Tree:", 'blue');
+        $this->_writeNewLine();
+    }
+
+    /**
+     * Callback called on a suite start.
+     *
+     * ### Format
+     * ```php
+     * {PIPE}{BRANCH}{$message}
+     * ```
+     *
+     * ### Output Example
+     * ```
+     * ├── UnionTypes
+     * ```
+     *
+     * @param \Kahlan\Suite|null $suite The suite instance.
+     * @return void
+     */
+    public function suiteStart($suite = null): void
+    {
+        $messages = $suite->messages();
+        $this->_count = count($messages);
+
+        if ($this->_count === 1) {
+            return;
+        }
+
+        $message = end($messages);
+        $pipes = str_repeat(self::PIPE, $this->_count - 2);
+
+        $this->write($pipes . self::BRANCH, 'dark-grey');
+        $this->write($message);
+        $this->_writeNewLine();
+    }
+
+    /**
+     * Callback called after a spec execution.
+     *
+     * ### Format
+     * ```php
+     * {PIPE}{$symbol}{SPEC_MESSAGE_SEPARATOR}{$specMessage}
+     * ```
+     *
+     * ### Output Example
+     * ```
+     * │  │  ✖   it should return 'int'
+     * ```
+     *
+     * @param \Kahlan\Log $log The log object of the whole spec.
+     * @return void
+     */
+    public function specEnd($log = null): void
+    {
+        $pipes = str_repeat(self::PIPE, $this->_count - 2);
+
+        $this->write($pipes, 'dark-grey');
+        $this->_reportSpecMessage($log);
+        $this->_writeNewLine();
+    }
+
+    /**
+     * Callback called at the end of specs processing.
+     *
+     * ### Output Example
+     * ```
+     *   Failure Tree(2):
+     *  ├── UnionTypes
+     *  │  ├── ::getType(mixed $value): string
+     *  │  │  ├── UnionTypes::getType(1)
+     *  │  │  ✖   it should return 'int'
+     *    expect->toBe() failed in `./spec/UnionTypes.spec.php` line 110
+     *
+     *    It expect actual to be identical to expected (===).
+     *
+     *    actual:
+     *      (string) "int"
+     *    expected:
+     *      (string) "integer"
+     *
+     *  ├── UnionTypes
+     *  │  ├── ::stringify(mixed $value): string
+     *  │  │  ├── UnionTypes::stringify(1.2)
+     *  │  │  ✖   it should return '1.2'
+     *    expect->toBe() failed in `./spec/UnionTypes.spec.php` line 189
+     *
+     *    It expect actual to be identical to expected (===).
+     *
+     *    actual:
+     *      (string) "1.2"
+     *    expected:
+     *      (double) 1.2
+     *
+     *
+     *  Expectations   : 8 Executed
+     *  Specifications : 0 Pending, 0 Excluded, 0 Skipped
+     *
+     *  Passed 6 of 8 FAIL (FAILURE: 2) in 0.106 seconds (using 2MB)
+     * ```
+     *
+     * @param \Kahlan\Summary $summary The execution summary instance.
+     * @return void
+     */
+    public function end($summary): void
+    {
+        $this->_writeNewLine();
+        $this->_reportSkipped($summary);
+
+        $failuresLog = [];
+        foreach ($summary->logs() as $log) {
+            if ($log->passed()) {
+                continue;
+            }
+
+            $failuresLog[] = $log;
+        }
+
+        $failuresCount = count($failuresLog);
+
+        if ($failuresCount) {
+            $this->write("Failure Tree($failuresCount):", 'red');
+            $this->_writeNewLine();
+            foreach ($failuresLog as $failureLog) {
+                $this->_reportFailureTree($failureLog);
+            }
+        }
+
+        $this->_writeNewLine();
+        $this->_reportSummary($summary);
+    }
+
+    /**
+     * Print an expectation report.
+     *
+     * ### Output Example
+     * ```
+     *  ├── UnionTypes
+     *  │  ├── ::getType(mixed $value): string
+     *  │  │  ├── UnionTypes::getType(1)
+     *  │  │  ✖   it should return 'int'
+     *    expect->toBe() failed in `./spec/UnionTypes.spec.php` line 110
+     *
+     *    It expect actual to be identical to expected (===).
+     *
+     *    actual:
+     *      (string) "int"
+     *    expected:
+     *      (string) "integer"
+     * ```
+     *
+     * @param \Kahlan\Log $log The Log instance.
+     * @return void
+     */
+    protected function _reportFailureTree($log): void
+    {
+        $messages = array_values(array_filter($log->messages()));
+        $failureMessage = array_pop($messages);
+        foreach ($messages as $index => $message) {
+            $messagePipes = str_repeat(self::PIPE, $index);
+
+            $this->write($messagePipes . self::BRANCH, 'dark-grey');
+            $this->write($message);
+            $this->_writeNewLine();
+        }
+
+        $failureMessagePipes = str_repeat(self::PIPE, count($messages) - 1);
+
+        $this->write($failureMessagePipes, 'dark-grey');
+        $this->_writeSpecMessage('err', 'red', $failureMessage, 'red');
+        $this->_writeNewLine();
+
+        $this->_reportFailure($log);
+    }
+
+    /**
+     * Print a spec message report using the log instance.
+     *
+     * ### Format
+     * ```php
+     * {$symbol}{SPEC_MESSAGE_SEPARATOR}{$specMessage}
+     * ```
+     *
+     * ### Output Examples
+     * Failed:
+     * ```
+     * ✖   it should return 'int'
+     * ```
+     * Passed:
+     * ```
+     * ✓   it should return '1'
+     * ```
+     *
+     * @param \Kahlan\Log $log A spec log instance.
+     * @return void
+     */
+    protected function _reportSpecMessage($log): void
+    {
+        $messages = $log->messages();
+        $message = end($messages);
+
+        switch ($log->type()) {
+            case 'passed':
+                $this->_writeSpecMessage('ok', 'light-green', $message, 'dark-grey');
+                break;
+            case 'skipped':
+                $this->_writeSpecMessage('ok', 'light-grey', $message, 'light-grey');
+                break;
+            case 'pending':
+                $this->_writeSpecMessage('ok', 'cyan', $message, 'cyan');
+                break;
+            case 'excluded':
+                $this->_writeSpecMessage('ok', 'yellow', $message, 'yellow');
+                break;
+            case 'failed':
+                $this->_writeSpecMessage('err', 'red', $message, 'red');
+                break;
+            case 'errored':
+                $this->_writeSpecMessage('err', 'red', $message, 'red');
+                break;
+        }
+    }
+
+    /**
+     * Print a spec message.
+     *
+     * ### Format
+     * ```php
+     * {$symbol}{SPEC_MESSAGE_SEPARATOR}{$specMessage}
+     * ```
+     *
+     * ### Output Examples
+     * Failed:
+     * ```
+     * ✖   it should return 'int'
+     * ```
+     * Passed:
+     * ```
+     * ✓   it should return '1'
+     * ```
+     *
+     * @param string $symbol The symbol name, see `Terminal::_symbols`, e.g. `ok`, `err`, `dot`.
+     * @param string $symbolColor The symbol color, e.g. `green`, `red`, `blue`, `yellow`, `light-grey`, `dark-grey`.
+     * @param string $message The spec message, e.g. `'it should return int'`.
+     * @param string $messageColor The message color, e.g. `green`, `red`, `blue`, `yellow`, `light-grey`, `dark-grey`.
+     * @return void
+     */
+    protected function _writeSpecMessage(
+        string $symbol,
+        string $symbolColor,
+        string $message,
+        string $messageColor
+    ): void {
+        $this->write($this->_symbols[$symbol], $symbolColor);
+        $this->write(self::SPEC_MESSAGE_SEPARATOR);
+        $this->write($message, $messageColor);
+    }
+
+    /**
+     * Print a new line.
+     *
+     * @return void
+     */
+    protected function _writeNewLine(): void
+    {
+        $this->write("\n");
+    }
+}

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 namespace Kahlan\Reporter;
 
@@ -357,12 +356,8 @@ class Tree extends Terminal
      * @param string $messageColor The message color, e.g. `green`, `red`, `blue`, `yellow`, `light-grey`, `dark-grey`.
      * @return void
      */
-    protected function _writeSpecMessage(
-        string $symbol,
-        string $symbolColor,
-        string $message,
-        string $messageColor
-    ) {
+    protected function _writeSpecMessage($symbol, $symbolColor, $message, $messageColor)
+    {
         $this->write($this->_symbols[$symbol], $symbolColor);
         $this->write(self::SPEC_MESSAGE_SEPARATOR);
         $this->write($message, $messageColor);

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -379,7 +379,7 @@ class Tree extends Terminal
      * @param int $count The new count value.
      * @return $this
      */
-    public function setCount(int $count)
+    public function setCount($count)
     {
         $this->_count = $count;
 

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -97,7 +97,7 @@ class Tree extends Terminal
      * @param array $args The suite arguments.
      * @return void
      */
-    public function start($args): void
+    public function start($args)
     {
         parent::start($args);
 
@@ -122,7 +122,7 @@ class Tree extends Terminal
      * @param object|null $suite The suite instance.
      * @return void
      */
-    public function suiteStart($suite = null): void
+    public function suiteStart($suite = null)
     {
         if ($suite === null) {
             return;
@@ -159,7 +159,7 @@ class Tree extends Terminal
      * @param \Kahlan\Log $log The log object of the whole spec.
      * @return void
      */
-    public function specEnd($log = null): void
+    public function specEnd($log = null)
     {
         if ($log === null) {
             return;
@@ -214,7 +214,7 @@ class Tree extends Terminal
      * @param \Kahlan\Summary $summary The execution summary instance.
      * @return void
      */
-    public function end($summary): void
+    public function end($summary)
     {
         $this->_writeNewLine();
         $this->_reportSkipped($summary);
@@ -264,7 +264,7 @@ class Tree extends Terminal
      * @param \Kahlan\Log $log The Log instance.
      * @return void
      */
-    protected function _reportFailureTree($log): void
+    protected function _reportFailureTree($log)
     {
         $messages = array_values(array_filter($log->messages()));
         $failureMessage = array_pop($messages);
@@ -306,7 +306,7 @@ class Tree extends Terminal
      * @param \Kahlan\Log $log A spec log instance.
      * @return void
      */
-    protected function _reportSpecMessage($log): void
+    protected function _reportSpecMessage($log)
     {
         $messages = $log->messages();
         $message = end($messages);
@@ -362,7 +362,7 @@ class Tree extends Terminal
         string $symbolColor,
         string $message,
         string $messageColor
-    ): void {
+    ) {
         $this->write($this->_symbols[$symbol], $symbolColor);
         $this->write(self::SPEC_MESSAGE_SEPARATOR);
         $this->write($message, $messageColor);
@@ -373,7 +373,7 @@ class Tree extends Terminal
      *
      * @return void
      */
-    protected function _writeNewLine(): void
+    protected function _writeNewLine()
     {
         $this->write("\n");
     }
@@ -384,7 +384,7 @@ class Tree extends Terminal
      * @param int $count The new count value.
      * @return $this
      */
-    public function setCount(int $count): Tree
+    public function setCount(int $count)
     {
         $this->_count = $count;
 

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -119,11 +119,15 @@ class Tree extends Terminal
      * ├── UnionTypes
      * ```
      *
-     * @param \Kahlan\Suite|null $suite The suite instance.
+     * @param object|null $suite The suite instance.
      * @return void
      */
     public function suiteStart($suite = null): void
     {
+        if ($suite === null) {
+            return;
+        }
+
         $messages = $suite->messages();
         $this->_count = count($messages);
 
@@ -157,6 +161,10 @@ class Tree extends Terminal
      */
     public function specEnd($log = null): void
     {
+        if ($log === null) {
+            return;
+        }
+
         $pipes = str_repeat(self::PIPE, $this->_count - 2);
 
         $this->write($pipes, 'dark-grey');
@@ -368,5 +376,18 @@ class Tree extends Terminal
     protected function _writeNewLine(): void
     {
         $this->write("\n");
+    }
+
+    /**
+     * Set the `_count` value.
+     *
+     * @param int $count The new count value.
+     * @return $this
+     */
+    public function setCount(int $count): Tree
+    {
+        $this->_count = $count;
+
+        return $this;
     }
 }

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -36,7 +36,7 @@ class Tree extends Terminal
      *
      * @var string
      */
-    protected const PIPE = '│  ';
+    const PIPE = '│  ';
 
     /**
      * The tree branch, used only for desciption messages.
@@ -55,7 +55,7 @@ class Tree extends Terminal
      *
      * @var string
      */
-    protected const BRANCH = '├── ';
+    const BRANCH = '├── ';
 
     /**
      * The spec message separator, used to separate the symbol from the message.
@@ -73,7 +73,7 @@ class Tree extends Terminal
      * │  │  ✓   it should return 'null'
      * ```
      */
-    protected const SPEC_MESSAGE_SEPARATOR = '   ';
+    const SPEC_MESSAGE_SEPARATOR = '   ';
 
     /**
      * Callback called before any specs processing.


### PR DESCRIPTION
A new reporter inspired from the **verbose** reporter and the **coverage** report, using **pipe** `│  ` and **branch** `├── ` instead of **space indentation**, e.g.:
```
├── UnionTypes
│  ├── ::assertTypes(string ...$types): void
│  │  ├── UnionTypes::assertTypes('NULL')
│  │  ✓   it should return 'null'
```

Screenshot:

![image](https://user-images.githubusercontent.com/1313482/70003864-cbe64480-1564-11ea-91ae-0f60acc349e0.png)
