### PR TITLE
Fix wrong return type in Allow class doc

### DIFF
--- a/src/Allow.php
+++ b/src/Allow.php
@@ -59,7 +59,7 @@ class Allow
      * Stub a chain of methods.
      *
      * @param  string $expected the method to be stubbed or a chain of methods.
-     * @return        self.
+     * @return        Stub\Method.
      */
     public function toReceive()
     {
@@ -72,7 +72,7 @@ class Allow
     /**
      * Stub function.
      *
-     * @return        self.
+     * @return        Stub\Method.
      */
     public function toBeCalled()
     {


### PR DESCRIPTION
My PHPStorm is yelling each time I use `toReceive()` and `toBeCalled()`.

Now I understand why 😄 