### PR TITLE
Fix `self` return typehint being generated with a leading slash

### DIFF
--- a/spec/Mock/Plugin/Double/HelloInterface.php
+++ b/spec/Mock/Plugin/Double/HelloInterface.php
@@ -5,7 +5,5 @@ interface HelloInterface
 {
     public function hello(): self;
 
-    public function hi(): static;
-
     public function aloha(): HelloInterface;
 }

--- a/spec/Mock/Plugin/Double/HelloInterface.php
+++ b/spec/Mock/Plugin/Double/HelloInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Kahlan\Spec\Mock\Plugin\Double;
+
+interface HelloInterface
+{
+    public function hello(): self;
+
+    public function hi(): static;
+
+    public function aloha(): HelloInterface;
+}

--- a/spec/Suite/Plugin/Double.spec.php
+++ b/spec/Suite/Plugin/Double.spec.php
@@ -764,6 +764,29 @@ EOD;
 
         });
 
+        it("stubs an interface with `self` return type hints", function () {
+
+            $result = Double::generate([
+                'implements' => 'Kahlan\Spec\Mock\Plugin\Double\HelloInterface',
+            ]);
+
+            $expected = <<<EOD
+<?php
+namespace Kahlan\\Spec\\Plugin\\Double;
+
+class Double0 implements \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {
+
+    public function hello() : self {}
+    public function hi() : static {}
+    public function aloha() : \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {}
+
+}
+?>
+EOD;
+            expect($result)->toBe($expected);
+
+        });
+
     });
 
 });

--- a/spec/Suite/Plugin/Double.spec.php
+++ b/spec/Suite/Plugin/Double.spec.php
@@ -767,20 +767,23 @@ EOD;
         it("stubs an interface with `self` return type hints", function () {
 
             $result = Double::generate([
+                'class' => 'Kahlan\Spec\Plugin\Double\Double',
                 'implements' => 'Kahlan\Spec\Mock\Plugin\Double\HelloInterface',
+                'magicMethods' => false,
+                'openTag' => false,
+                'closeTag' => false,
             ]);
 
             $expected = <<<EOD
-<?php
 namespace Kahlan\\Spec\\Plugin\\Double;
 
-class Double0 implements \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {
+class Double implements \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {
 
     public function hello() : self {}
     public function aloha() : \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {}
 
 }
-?>
+
 EOD;
             expect($result)->toBe($expected);
 

--- a/spec/Suite/Plugin/Double.spec.php
+++ b/spec/Suite/Plugin/Double.spec.php
@@ -777,7 +777,6 @@ namespace Kahlan\\Spec\\Plugin\\Double;
 class Double0 implements \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {
 
     public function hello() : self {}
-    public function hi() : static {}
     public function aloha() : \Kahlan\Spec\Mock\Plugin\Double\HelloInterface {}
 
 }

--- a/src/Plugin/Double.php
+++ b/src/Plugin/Double.php
@@ -404,6 +404,10 @@ EOT;
     protected static function _generateReturnType($method)
     {
         $typehint = Inspector::returnTypehint($method->getReturnType());
+        $trimmed = ltrim($typehint, '\\');
+        if (in_array($trimmed, [ 'self', 'static' ])) {
+            $typehint = $trimmed;
+        }
         return $typehint ? ": {$typehint} " : '';
     }
 

--- a/src/Plugin/Double.php
+++ b/src/Plugin/Double.php
@@ -405,7 +405,7 @@ EOT;
     {
         $typehint = Inspector::returnTypehint($method->getReturnType());
         $trimmed = ltrim($typehint, '\\');
-        if (in_array($trimmed, [ 'self', 'static' ])) {
+        if (in_array($trimmed, [ 'self', 'static' ], true)) {
             $typehint = $trimmed;
         }
         return $typehint ? ": {$typehint} " : '';


### PR DESCRIPTION
Hi :wave: 

First, thanks for making my favourite test framework :blush: 

Second, I've come across a small bug this afternoon where, when trying to create a double for an interface with a `self` return typehint, `\self` was generated instead.

Quick example - with the following interface:

```php
interface Message
{
    public function setId(MessageId $id): self;
}
```

And the following test code:

```php
$message = Double::instance([
    'implements' => Message::class,
]);
```

This resulted in:

```
PHP Fatal error:  '\self' is an invalid class name in /server/http/vendor/kahlan/kahlan/src/Plugin/Double.php(104) : eval()'d code on line 7
```

This PR is just a quick fix to get past this.

Let me know if there's anything more you need from me on this!