### PR TITLE
PHP 8.2: Fix deprecated uft8-decode

### DIFF
--- a/src/Reporter/Coverage.php
+++ b/src/Reporter/Coverage.php
@@ -240,7 +240,7 @@ class Coverage extends Terminal
             $style = $this->_style($percent);
 
             $prefix = join('', $this->_prefixes) . ' ';
-            $diff = strlen($prefix) - strlen(utf8_decode($prefix));
+            $diff = strlen($prefix) - strlen(mb_convert_encoding($prefix, 'ISO-8859-1'));
 
             $type = $metrics->type();
             $color = $type === 'function' || $type === 'method' ? 'd' : '';


### PR DESCRIPTION
@yitznewton this is to fix https://github.com/kahlan/kahlan/issues/406

Ref https://3v4l.org/ZuZl5