### PR TITLE
Drop php 7.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4"

--- a/spec/Suite/Plugin/Quit.spec.php
+++ b/spec/Suite/Plugin/Quit.spec.php
@@ -93,7 +93,7 @@ describe("Quit", function () {
 
         it("throws an exception with never return type", function () {
 
-            skipIf(PHP_VERSION_ID < 70100);
+            skipIf(PHP_VERSION_ID < 80100);
 
             Quit::disable();
             $closure = function () {


### PR DESCRIPTION
PHP 7.1 already reached its end of life long time at December 1st, 2019, and composer >2.3.x no longer support it, ref https://getcomposer.org/doc/00-intro.md#system-requirements

@jails I think we can remove it support.