### PR TITLE
Bump to Rector 0.18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",
-        "rector/rector": "^0.17.14"
+        "rector/rector": "^0.18"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Rector tagged 0.17.14 is removed and bump to 0.18.0 instead due to DI migration. This PR fix it to avoid error can't install Rector 0.17.14.