### PR TITLE
Implement withEach()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.4",
+        "squizlabs/php_codesniffer": "~3.7.2",
         "rector/rector": "^0.18"
     },
     "autoload": {

--- a/spec/Suite/Block/Builder/CasesBuilder.spec.php
+++ b/spec/Suite/Block/Builder/CasesBuilder.spec.php
@@ -1,0 +1,109 @@
+<?php
+namespace Kahlan\Spec\Suite\Block;
+
+use Kahlan\Arg;
+use Kahlan\Block\Builder\CasesBuilder;
+use Kahlan\Block\Group;
+use Kahlan\Scope\Specification;
+use Kahlan\Plugin\Double;
+
+describe('CasesBuilder', function () {
+
+    $this->cases = [
+        'first case' => ['a', 1],
+        'second case' => ['b', 2],
+        42 => ['c', 3],
+    ];
+
+    beforeEach(function () {
+
+        $this->group = new Group();
+
+    });
+
+    it('should add specs for each array pair', function () {
+
+        $builder = new CasesBuilder($this->group, $this->cases, null, 'normal');
+        $builder->it('should receive');
+        $children = $this->group->children();
+
+        expect($children)->toHaveLength(3);
+
+        expect($children[0]->message())->toBe('it should receive first case');
+        expect($children[0]->timeout())->toBe(0);
+        expect($children[0]->type())->toBe('normal');
+
+        expect($children[1]->message())->toBe('it should receive second case');
+        expect($children[1]->timeout())->toBe(0);
+        expect($children[1]->type())->toBe('normal');
+
+        expect($children[2]->message())->toBe('it should receive 42');
+        expect($children[2]->timeout())->toBe(0);
+        expect($children[2]->type())->toBe('normal');
+
+    });
+
+    it('should add specs for each iterator pair', function () {
+
+        $builder = new CasesBuilder($this->group, new \ArrayIterator($this->cases), 10, 'focus');
+        $builder->it('should receive');
+        $children = $this->group->children();
+
+        expect($children)->toHaveLength(3);
+
+        expect($children[0]->message())->toBe('it should receive first case');
+        expect($children[0]->timeout())->toBe(10);
+        expect($children[0]->type())->toBe('focus');
+
+        expect($children[1]->message())->toBe('it should receive second case');
+        expect($children[1]->timeout())->toBe(10);
+        expect($children[1]->type())->toBe('focus');
+
+        expect($children[2]->message())->toBe('it should receive 42');
+        expect($children[2]->timeout())->toBe(10);
+        expect($children[2]->type())->toBe('focus');
+
+    });
+
+    it('should call closure with case params', function () {
+
+        $closure = Double::instance();
+        $boundClosure = Double::instance();
+
+        allow($closure)
+            ->toReceive('bindTo')
+            ->with(Arg::toBeAnInstanceOf(Specification::class))
+            ->andReturn($boundClosure);
+
+        expect($boundClosure)
+            ->toReceive('__invoke')
+            ->with('a', 1)
+            ->ordered;
+
+        expect($boundClosure)
+            ->toReceive('__invoke')
+            ->with('b', 2)
+            ->ordered;
+
+        expect($boundClosure)
+            ->toReceive('__invoke')
+            ->with('c', 3)
+            ->ordered;
+
+        $builder = new CasesBuilder($this->group, $this->cases, null, 'normal');
+        $builder->it('should receive', $closure);
+
+        $this->group->process();
+
+    });
+
+    it('should do nothing with empty cases', function () {
+
+        $builder = new CasesBuilder($this->group, [], null, 'normal');
+        $builder->it('should receive');
+
+        expect($this->group->children())->toHaveLength(0);
+
+    });
+
+});

--- a/spec/Suite/Block/Group.spec.php
+++ b/spec/Suite/Block/Group.spec.php
@@ -52,4 +52,16 @@ describe("Group", function () {
 
     });
 
+    describe("->withEach", function () {
+
+        it("adds spec for each case", function () {
+
+            $this->group->withEach([[1], [2], [3]])->it("it", function () {});
+
+            expect($this->group->children())->toHaveLength(3);
+
+        });
+
+    });
+
 });

--- a/src/Block/Builder/CasesBuilder.php
+++ b/src/Block/Builder/CasesBuilder.php
@@ -1,0 +1,75 @@
+<?php
+namespace Kahlan\Block\Builder;
+
+use Kahlan\Block\Group;
+use Closure;
+
+class CasesBuilder
+{
+    /**
+     * The group.
+     *
+     * @var Group
+     */
+    private $_group;
+
+    /**
+     * The test cases.
+     *
+     * @var iterable<array-key, array>
+     */
+    private $_cases;
+
+    /**
+     * The timeout value.
+     *
+     * @var integer|null
+     */
+    private $_timeout;
+
+    /**
+     * The type.
+     *
+     * @var string
+     */
+    private $_type;
+
+    /**
+     * The Constructor.
+     *
+     * @param Group                      $group   The Group to add cases to.
+     * @param iterable<array-key, array> $cases   The test cases.
+     * @param integer|null               $timeout The timeout value.
+     * @param string                     $type    The type.
+     */
+    public function __construct($group, $cases, $timeout, $type)
+    {
+        $this->_group = $group;
+        $this->_cases = $cases;
+        $this->_timeout = $timeout;
+        $this->_type = $type;
+    }
+
+    /**
+     * Adds a spec for each test case.
+     *
+     * @param string  $message Description message.
+     * @param Closure $closure A test case closure.
+     * @return void
+     */
+    public function it($message, $closure = null)
+    {
+        foreach ($this->_cases as $name => $args) {
+            $this->_group->it(
+                "{$message} {$name}",
+                $closure !== null
+                    ? function () use ($closure, $args) {
+                        return $closure->bindTo($this)(...$args);
+                    }
+                    : null,
+                $this->_timeout,
+                $this->_type
+            );
+        }
+    }
+}

--- a/src/Block/Group.php
+++ b/src/Block/Group.php
@@ -2,6 +2,7 @@
 namespace Kahlan\Block;
 
 use Kahlan\Block;
+use Kahlan\Block\Builder\CasesBuilder;
 use Closure;
 use Exception;
 use Throwable;
@@ -254,6 +255,19 @@ class Group extends Block
         $this->_children[] = $spec;
 
         return $this;
+    }
+
+    /**
+     * Add multiple specs using the given test cases.
+     *
+     * @param  iterable<array-key, array> $cases   The test cases.
+     * @param  integer|null               $timeout The timeout value.
+     * @param  string                     $type    The type.
+     * @return CasesBuilder
+     */
+    public function withEach($cases, $timeout = null, $type = 'normal')
+    {
+        return new CasesBuilder($this, $cases, $timeout, $type);
     }
 
     /**

--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -730,6 +730,19 @@ namespace {
         } else {
             $exit('it');
         }
+        if (!function_exists('withEach')) {
+            /**
+             * @param iterable<array-key, array> $cases
+             *
+             * @return CasesBuilder
+             */
+            function withEach($cases, $timeout = null, $type = 'normal')
+            {
+                return Suite::current()->withEach($cases, $timeout, $type);
+            }
+        } else {
+            $exit('withEach');
+        }
         if (!function_exists('fdescribe')) {
             function fdescribe($message, $closure, $timeout = null)
             {
@@ -754,6 +767,19 @@ namespace {
         } else {
             $exit('fit');
         }
+        if (!function_exists('fwithEach')) {
+            /**
+             * @param iterable<array-key, array> $cases
+             *
+             * @return CasesBuilder
+             */
+            function fwithEach($cases, $timeout = null)
+            {
+                return withEach($cases, $timeout, 'focus');
+            }
+        } else {
+            $exit('fwithEach');
+        }
         if (!function_exists('xdescribe')) {
             function xdescribe($message, $closure, $timeout = null)
             {
@@ -777,6 +803,19 @@ namespace {
             }
         } else {
             $exit('xit');
+        }
+        if (!function_exists('xwithEach')) {
+            /**
+             * @param iterable<array-key, array> $cases
+             *
+             * @return CasesBuilder
+             */
+            function xwithEach($cases, $timeout = null)
+            {
+                return withEach($cases, $timeout, 'exclude');
+            }
+        } else {
+            $exit('xwithEach');
         }
         if (!function_exists('waitsFor')) {
             function waitsFor($actual, $timeout = 60)

--- a/src/functions.php
+++ b/src/functions.php
@@ -48,6 +48,16 @@ function it($message, $closure = null, $timeout = null, $type = 'normal')
     return Suite::current()->it($message, $closure, $timeout, $type);
 }
 
+/**
+ * @param iterable<array-key, array> $cases
+ *
+ * @return CasesBuilder
+ */
+function withEach($cases, $timeout = null, $type = 'normal')
+{
+    return Suite::current()->withEach($cases, $timeout, $type);
+}
+
 function fdescribe($message, $closure, $timeout = null)
 {
     return describe($message, $closure, $timeout, 'focus');
@@ -63,6 +73,16 @@ function fit($message, $closure = null, $timeout = null)
     return it($message, $closure, $timeout, 'focus');
 }
 
+/**
+ * @param iterable<array-key, array> $cases
+ *
+ * @return CasesBuilder
+ */
+function fwithEach($cases, $timeout = null)
+{
+    return withEach($cases, $timeout, 'focus');
+}
+
 function xdescribe($message, $closure, $timeout = null)
 {
     return describe($message, $closure, $timeout, 'exclude');
@@ -76,6 +96,16 @@ function xcontext($message, $closure, $timeout = null)
 function xit($message, $closure = null, $timeout = null)
 {
     return it($message, $closure, $timeout, 'exclude');
+}
+
+/**
+ * @param iterable<array-key, array> $cases
+ *
+ * @return CasesBuilder
+ */
+function xwithEach($cases, $timeout = null)
+{
+    return withEach($cases, $timeout, 'exclude');
 }
 
 function waitsFor($actual, $timeout = null)


### PR DESCRIPTION
Hello 🙂 I'm trying to switch from PHPUnit to Kahlan. The only feature I'm missing is some equivalent of "data providers".

I've noticed that this has already been discussed in #146, but so far I don't see a built-in solution.

I'm aware that it's possible to just use custom functions for this purpose, but I think this feature is basic enough to perhaps be worth including in the framework itself. So here is my attempt at implementing this.

- I've tried to keep it as simple as possible - it's just syntax sugar for calling `it()` multiple times
- `withEach()` takes any iterable, so generators or other iterators will work too
- `fwithEach()` and `xwithEach()` apply that type to all cases
- on PHP 8+, named arguments may be used in each case, making them more readable

```php
describe('Example', function () {

    withEach([
        'empty string' => ['', 0],
        'simple string' => ['foo bar', 7],
        'UTF-8 string' => ['žluťoučký kůň', 13],
    ])->it('should get length of', function (string $string, int $expectedLength) {
        expect(mb_strlen($string))->toBe($expectedLength);
    });

});
```

Output:

```
  Example
    ✓ it should get length of empty string
    ✓ it should get length of simple string
    ✓ it should get length of UTF-8 string
```

The equivalent `foreach` solution would be something like this, which doesn't look very nice imo.

```php
$cases = [
    'empty string' => ['', 0],
    'simple string' => ['foo bar', 7],
    'UTF-8 string' => ['žluťoučký kůň', 13],
];

foreach ($cases as $name => [$string, $expectedLength]) {
    it('should get length of ' . $name, function () use ($string, $expectedLength) {
        expect(mb_strlen($string))->toBe($expectedLength);
    });
}
```