### PR TITLE
Fix deprecation warning in Coverage

### DIFF
--- a/src/Reporter/Coverage.php
+++ b/src/Reporter/Coverage.php
@@ -341,7 +341,7 @@ class Coverage extends Terminal
             }
 
             for ($i = $start; $i <= $stop; $i++) {
-                $value = $coverage[$i] ?? null;
+                $value = $coverage[$i] ?? '';
                 $line = str_pad($i + 1, 6, ' ', STR_PAD_LEFT);
                 $line .= ':' . str_pad($value, 6, ' ');
                 $line .= $lines[$i];


### PR DESCRIPTION
Fix the following warning message in `Coverage.php`:

```bash
PHP Deprecated:  str_pad(): Passing null to parameter #1 ($string) of type string is deprecated in C:\...\vendor\kahlan\kahlan\src\Reporter\Coverage.php on line 346
```