### PR TITLE
Fix run on windows: directory separator, ✓ and ✖ char (part 1)

### DIFF
--- a/spec/Suite/Jit/ClassLoader.spec.php
+++ b/spec/Suite/Jit/ClassLoader.spec.php
@@ -658,7 +658,7 @@ describe("ClassLoader", function () {
             expect($this->loader->prefixes())->toBe([
                 'Kahlan\\' => ['src'],
                 'Kahlan\\Spec\\' => ['spec'],
-                'Psr0' => ['psr0/Psr0']
+                'Psr0' => ['psr0' . DS .'Psr0']
             ]);
 
         });

--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -320,7 +320,7 @@ To add additional values, just repeat the same option many times in the command 
 
 
 EOD;
-            $terminal->write(str_replace("\r\n", "\n", $help));
+            $terminal->write($help);
             QuitStatement::quit();
         }
 

--- a/src/Cli/Kahlan.php
+++ b/src/Cli/Kahlan.php
@@ -320,7 +320,7 @@ To add additional values, just repeat the same option many times in the command 
 
 
 EOD;
-            $terminal->write($help);
+            $terminal->write(str_replace("\r\n", "\n", $help));
             QuitStatement::quit();
         }
 

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -406,6 +406,8 @@ EOD;
      */
     public function write($string, $options = null)
     {
+        // normalize line endings
+        $string = str_replace("\r\n", "\n", $string);
         $indent = str_repeat($this->_indentValue, $this->indent()) . $this->prefix();
 
         if ($newLine = ($string && $string[strlen($string) - 1] === "\n")) {

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -106,8 +106,8 @@ class Terminal extends Reporter
         $this->colors($config['colors']);
 
         if (!$this->colors() && getenv('ComSpec')) {
-            $this->_symbols['ok'] = "\xFB";
-            $this->_symbols['err'] = "\x78";
+            $this->_symbols['ok'] = "\xE2\x9C\x93";
+            $this->_symbols['err'] = "\xE2\x9C\x96";
             $this->_symbols['dot'] = '.';
         }
 

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -406,8 +406,6 @@ EOD;
      */
     public function write($string, $options = null)
     {
-        // normalize line endings
-        $string = str_replace("\r\n", "\n", $string);
         $indent = str_repeat($this->_indentValue, $this->indent()) . $this->prefix();
 
         if ($newLine = ($string && $string[strlen($string) - 1] === "\n")) {


### PR DESCRIPTION
1. directory separator needs explicit use `DS` on test to avoid got `\` expected `/` on windows env
2. \xFB detected as � on windows
3.  \x78 detected as normal x on windows