### PR TITLE
Fix run on windows: new line fix on Kahlan.spec.php and Tree.spec.php (part 3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: vendor/bin/rector --dry-run
 
       - name: Run test suite
-        run: bin/kahlan --config=kahlan-config-github-action.php --clover=clover.xml
+        run: php bin/kahlan --config=kahlan-config-github-action.php --clover=clover.xml
 
       - name: Upload coverage to Codecov
         if: matrix.php-versions == '7.4' && matrix.os == 'ubuntu-latest' && github.event.pull_request.head.repo.full_name == 'kahlan/kahlan'

--- a/spec/Suite/Cli/Kahlan.spec.php
+++ b/spec/Suite/Cli/Kahlan.spec.php
@@ -129,6 +129,9 @@ EOD;
             };
 
             Quit::disable();
+
+            $expected = str_replace("\r\n", "\n", $expected);
+
             expect($closure)->toEcho($expected);
 
         });
@@ -209,6 +212,9 @@ EOD;
             };
 
             Quit::disable();
+
+            $help = str_replace("\r\n", "\n", $help);
+
             expect($closure)->toEcho($help);
 
         });
@@ -235,6 +241,9 @@ EOD;
             };
 
             Quit::disable();
+
+            $message = str_replace("\r\n", "\n", $message);
+
             expect($closure)->toEcho($message);
 
         });
@@ -265,6 +274,9 @@ EOD;
             };
 
             Quit::disable();
+
+            $message = str_replace("\r\n", "\n", $message);
+
             expect($closure)->toEcho($message);
 
         });

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -33,8 +33,9 @@ describe("Tree", function () {
             $tree->start(['total' => 0]);
 
             fseek($this->file, 0);
-            $expected = stream_get_contents($this->file);
-            expect($expected)->toBe(sprintf(file_get_contents('spec/Fixture/Reporter/Console/start.txt'), $this->srcDir, $this->specDir));
+            $actual = str_replace("\r\n", "\n", stream_get_contents($this->file));
+            $expected = sprintf(file_get_contents('spec/Fixture/Reporter/Console/start.txt'), $this->srcDir, $this->specDir);
+            expect($actual)->toBe($expected);
         });
     });
 


### PR DESCRIPTION
Fixes notice on powershell:

```
Tree
  ->start($args)
    ✖ it should write the `start` message to the console
      expect->toBe() failed in `.spec\Suite\Reporter\Tree.spec.php` line 38

      It expect actual to be identical to expected (===).

      actual:
        (string) "            _     _\r\n  /\\ /\\__ _| |__ | | __ _ _ __\r\n / //_/ _` | '_ \\| |/ _` | '_ \\\r\n/ __ \\ (_| | | | | | (_| | | | |\r\n\\/  \\/\\__,_|_| |_|_|\\__,_|_| |_|\n\nThe PHP Test Framework for Freedom, Truth and Justice.\n\nsrc directory  : C:\\Users\\samso\\www\\kahlan\\src\nspec directory : C:\\Users\\samso\\www\\kahlan\\spec\n\nSpec Tree:\n"
      expected:
        (string) "            _     _\n  /\\ /\\__ _| |__ | | __ _ _ __\n / //_/ _` | '_ \\| |/ _` | '_ \\\n/ __ \\ (_| | | | | | (_| | | | |\n\\/  \\/\\__,_|_| |_|_|\\__,_|_| |_|\n\nThe PHP Test Framework for Freedom, Truth and Justice.\n\nsrc directory  : C:\\Users\\samso\\www\\kahlan\\src\nspec directory : C:\\Users\\samso\\www\\kahlan\\spec\n\nSpec Tree:\n"
```