### PR TITLE
Fix Tree pipes when an exception occurs

### DIFF
--- a/spec/Suite/Reporter/Terminal.spec.php
+++ b/spec/Suite/Reporter/Terminal.spec.php
@@ -3,6 +3,9 @@ namespace Kahlan\Spec\Suite\Reporter\Coverage;
 
 use Kahlan\Reporter\Terminal;
 
+use function Kahlan\describe;
+use function Kahlan\expect;
+
 describe("Terminal", function () {
 
     beforeEach(function () {
@@ -99,6 +102,15 @@ EOD;
 
         });
 
+    });
+
+    describe('->write()', function () {
+
+        it("does not throw when a null message is given", function () {
+            expect(function () {
+                $this->terminal->write(null);
+            })->not->toThrow();
+        });
     });
 
 });

--- a/spec/Suite/Reporter/Tree.spec.php
+++ b/spec/Suite/Reporter/Tree.spec.php
@@ -186,10 +186,19 @@ describe("Tree", function () {
     });
 
     describe('->specEnd($log = null)', function () {
+
         it('should return if `$log === null`', function () {
             $tree = new Tree();
             $expect = $tree->specEnd(null);
             expect($expect)->toBeNull();
+        });
+
+        it('should work with a failed log with an empty message', function () {
+            $tree = new Tree();
+            $log = new Log('failed', []);
+            expect(function () use ($tree, $log) {
+                $tree->specEnd($log);
+            })->not->toThrow();
         });
 
         it("should write the `specEnd` message to the console", function () {
@@ -273,6 +282,15 @@ describe("Tree", function () {
     });
 
     describe('->end($summary)', function () {
+
+        it('should work with a summary that has one empty, failed log', function () {
+            $tree = new Tree();
+            $log = new Log('failed', []);
+            $summary = new Summary([ $log ]);
+            expect(function () use ($tree, $summary) {
+                $tree->end($summary);
+            })->not->toThrow();
+        });
 
         it("should write the `end` message to the console", function () {
 

--- a/src/Reporter/Terminal.php
+++ b/src/Reporter/Terminal.php
@@ -406,6 +406,10 @@ EOD;
      */
     public function write($string, $options = null)
     {
+        if ($string === null) {
+            $string = '';
+        }
+
         $indent = str_repeat($this->_indentValue, $this->indent()) . $this->prefix();
 
         if ($newLine = ($string && $string[strlen($string) - 1] === "\n")) {

--- a/src/Reporter/Tree.php
+++ b/src/Reporter/Tree.php
@@ -185,7 +185,8 @@ class Tree extends Terminal
             return;
         }
 
-        $pipes = str_repeat(self::PIPE, $this->_count - 2);
+        $times = $this->_count - 2;
+        $pipes = str_repeat(self::PIPE, $times < 0 ? 0 : $times);
 
         $this->write($pipes, 'dark-grey');
         $this->_reportSpecMessage($log);
@@ -296,7 +297,8 @@ class Tree extends Terminal
             $this->_writeNewLine();
         }
 
-        $failureMessagePipes = str_repeat(self::PIPE, count($messages) - 1);
+        $times = count($messages) - 1;
+        $failureMessagePipes = str_repeat(self::PIPE, $times < 0 ? 0 : $times);
 
         $this->write($failureMessagePipes, 'dark-grey');
         $this->_writeSpecMessage('err', 'red', $failureMessage, 'red');


### PR DESCRIPTION
Given an example like this:

```php
declare(strict_types=1);

describe( 'A', function(): void {

    beforeAll( function(): void {
        throw new Error( 'Oops' );
    } );

    it( 'should work', function(): void {
        expect( 1 )->toBeTruthy();
    } );

} );
```

Output is:

```bash
Failure Tree(1):

Fatal error: Uncaught ValueError: str_repeat(): Argument #2 ($times) must be greater than or equal to 0 in C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Reporter\Tree.php:299
Stack trace:
#0 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Reporter\Tree.php(299): str_repeat('\xE2\x94\x82  ', -1)
#1 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Reporter\Tree.php(257): Kahlan\Reporter\Tree->_reportFailureTree(Object(Kahlan\Log))
#2 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Reporters.php(84): Kahlan\Reporter\Tree->end(Object(Kahlan\Summary))
#3 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Suite.php(304): Kahlan\Reporters->dispatch('end', Object(Kahlan\Summary))
#4 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Suite.php(224): Kahlan\Suite->report('end', Object(Kahlan\Summary))
#5 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Cli\Kahlan.php(573): Kahlan\Suite->run(Array)
#6 [internal function]: Kahlan\Cli\Kahlan->{closure:Kahlan\Cli\Kahlan::_run():573}(Object(Closure))
#7 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Filter\Filters.php(204): call_user_func_array(Object(Closure), Array)
#8 [internal function]: Kahlan\Filter\Filters::{closure:Kahlan\Filter\Filters::run():199}()
#9 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Filter\Filters.php(206): call_user_func_array(Object(Closure), Array)
#10 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Cli\Kahlan.php(573): Kahlan\Filter\Filters::run(Object(Kahlan\Cli\Kahlan), 'run', Array, Object(Closure))
#11 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Cli\Kahlan.php(378): Kahlan\Cli\Kahlan->_run()
#12 [internal function]: Kahlan\Cli\Kahlan->{closure:Kahlan\Cli\Kahlan::run():367}(Object(Closure))
#13 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Filter\Filters.php(204): call_user_func_array(Object(Closure), Array)
#14 [internal function]: Kahlan\Filter\Filters::{closure:Kahlan\Filter\Filters::run():199}()
#15 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Filter\Filters.php(206): call_user_func_array(Object(Closure), Array)
#16 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Cli\Kahlan.php(367): Kahlan\Filter\Filters::run(Object(Kahlan\Cli\Kahlan), 'workflow', Array, Object(Closure))
#17 C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\bin\kahlan(71): Kahlan\Cli\Kahlan->run()
#18 C:\code\tmp\kahlan-test\vendor\bin\kahlan(119): include('C:\\code\\oss\\ses...')
#19 {main}
  thrown in C:\code\tmp\kahlan-test\vendor\kahlan\kahlan\src\Reporter\Tree.php on line 299
```

This PR provides the fix.
It works as expected after the fix.